### PR TITLE
Fix EmailDomain suffix

### DIFF
--- a/CASAuthSettings.php.template
+++ b/CASAuthSettings.php.template
@@ -100,6 +100,7 @@ function casNameLookup($username) {
 #
 # Default: Returns $username@EmailDomain
 function casEmailLookup($username) {
+  global $CASAuth;
   return $username."@".$CASAuth["EmailDomain"];
 }
 


### PR DESCRIPTION
reference to `$CASAuth` global variable fails unless keyword `global` is used.
