### PR TITLE
CA Certificate Support and Pre-Login Authentication Check

### DIFF
--- a/CASAuth.php
+++ b/CASAuth.php
@@ -233,7 +233,7 @@ function casPostAuth($ticket2logout) {
 
         // create a new session where we'll store the old session data
         session_name("casauthssoutticket");
-        session_id(preg_replace('/[^\w]/','',$ticket2logout));
+        session_id(preg_replace('/[^a-zA-Z0-9\-]/','',$ticket2logout));
         session_start();
 
         $_SESSION["old_session_name"] = $old_session_name;
@@ -257,7 +257,7 @@ function casSingleSignOut($ticket2logout) {
 
         require_once($CASAuth["phpCAS"]."/CAS.php");
 
-        $session_id = preg_replace('/[^\w]/','',$ticket2logout);
+        $session_id = preg_replace('/[^a-zA-Z0-9\-]/','',$ticket2logout);
 
         // destroy a possible application session created before phpcas
         if(session_id() !== ""){

--- a/CASAuth.php
+++ b/CASAuth.php
@@ -110,7 +110,6 @@ function casLogin($user, &$result) {
 
                         // Get username
                         $username = casNameLookup(phpCAS::getUser());
-                        $email    = casEmailLookup(phpCAS::getUser());
 
                         // If we are restricting users AND the user is not in
                         // the allowed users list, lets block the login
@@ -127,9 +126,12 @@ function casLogin($user, &$result) {
 
                         // Create a new account if the user does not exists
                         if ($u->getID() == 0 && $CASAuth["CreateAccounts"]) {
+                          //Get email and realname
+                          $realname = casRealNameLookup(phpCAS::getUser());
+                          $email    = casEmailLookup(phpCAS::getUser());
                           // Create the user
                           $u->addToDatabase();
-                          $u->setRealName($username);
+                          $u->setRealName($realname);
                           $u->setEmail($email);
                           // PwdSecret is used to salt the username, which is
                           // then used to create an md5 hash which becomes the

--- a/CASAuth.php
+++ b/CASAuth.php
@@ -29,7 +29,7 @@
 
 $wgExtensionCredits["other"][] = array(
         "name"        => "CASAuth",
-        "version"     => "2.0.3-ucb",
+        "version"     => "2.0.4",
         "author"      => "Ioannis Yessios, Hauke Pribnow, Aaron Russo, Jeffrey Gill",
         "url"         => "https://github.com/CWRUChielLab/CASAuth",
         "description" => "Overrides MediaWiki's Authentication and implements Central Authentication Service (CAS) Authentication.  Original url: http://www.mediawiki.org/wiki/Extension:CASAuthentication"

--- a/CASAuth.php
+++ b/CASAuth.php
@@ -54,7 +54,7 @@ $CASAuth = array(
 );
 
 # load our custom configuration
-require_once("$IP/extensions/CASAuth/CASAuthSettings.php");
+require_once(__DIR__ . "/CASAuthSettings.php");
 
 //--------------------------------------------------------------------------
 // CASAuth

--- a/CASAuth.php
+++ b/CASAuth.php
@@ -93,9 +93,7 @@ function casLogin($user, &$result) {
 
         if (isset($_REQUEST["title"])) {
 
-                $lg = Language::factory($wgLanguageCode);
-
-                if ($_REQUEST["title"] == $lg->specialPage("Userlogin")) {  
+                if ($_REQUEST["title"] == SpecialPage::getTitleFor("Userlogin")->getPrefixedDBkey()) {
                         // Setup for a web request
                         require_once("$IP/includes/WebStart.php");
 
@@ -163,7 +161,7 @@ function casLogin($user, &$result) {
                           }
                         }
                 }
-                else if ($_REQUEST["title"] == $lg->specialPage("Userlogout"))
+                else if ($_REQUEST["title"] == SpecialPage::getTitleFor("Userlogout")->getPrefixedDBkey())
                   {
                     // Logout
                     casLogout();
@@ -190,7 +188,7 @@ function casLogout() {
         if ($returnto) {
                 $lg = Language::factory($wgLanguageCode);
                 $target = Title::newFromText($returnto);
-                if ($target && $target->getPrefixedDBkey() != $lg->specialPage("Userlogout")) {
+                if ($target && $target->getPrefixedDBkey() != SpecialPage::getTitleFor("Userlogout")->getPrefixedDBkey()) {
                         $redirecturl = $target->getFullUrl();
                 }
         }

--- a/CASAuth.php
+++ b/CASAuth.php
@@ -150,7 +150,7 @@ function casLogin($user, &$result) {
                         if ($CASAuth["RememberMe"]) {
                           $u->setOption("rememberpassword", 1);
                         }
-                        $u->setCookies();
+                        $u->setCookies(null, null, $CASAuth["RememberMe"]);
                         $user = $u;
 
                         // Redirect if a returnto parameter exists

--- a/CASAuth.php
+++ b/CASAuth.php
@@ -3,9 +3,8 @@
  * CASification script for MediaWiki 1.16 with phpCAS 1.2.1
  *
  * Requires phpCAS: http://www.ja-sig.org/wiki/display/CASC/phpCAS
- * Install by adding these lines to LocalSetting.php:
+ * Install by adding this line to LocalSetting.php:
  *  require_once("$IP/extensions/CASAuth/CASAuth.php");
- *  casSetup();
  *
  * *** Please keep all configuration in the CASAuth.conf file ***
  *
@@ -89,18 +88,14 @@ function casLogoutCheck() {
 function casLogin($user) {
         global $CASAuth;
         global $casIsSetUp;
-        global $IP, $wgRequest, $wgOut;
+        global $wgRequest, $wgOut;
 
         if (isset($_REQUEST["title"])) {
 
                 if ($_REQUEST["title"] == SpecialPage::getTitleFor("Userlogin")->getPrefixedDBkey()) {
-                        // Setup for a web request
-                        require_once("$IP/includes/WebStart.php");
-
                         // Load phpCAS
-                        require_once($CASAuth["phpCAS"]."/CAS.php");
                         if(!$casIsSetUp)
-                                return false;
+                                casSetup();
 
                         //Will redirect to CAS server if not logged in
                         phpCAS::forceAuthentication();
@@ -173,8 +168,6 @@ function casLogout() {
         global $casIsSetUp;
         global $wgRequest;
 
-        require_once($CASAuth["phpCAS"]."/CAS.php");
-
         // Get returnto value
         $returnto = $wgRequest->getVal("returnto");
         if ($returnto) {
@@ -185,7 +178,7 @@ function casLogout() {
         }
 
         if(!$casIsSetUp)
-                return false;
+                casSetup();
 
         // Logout from CAS (will redirect user to CAS server)
 
@@ -242,9 +235,6 @@ function casPostAuth($ticket2logout) {
 // The CAS server sent a single sign-out command... let's process it
 function casSingleSignOut($ticket2logout) {
         global $CASAuth;
-        global $IP;
-
-        require_once($CASAuth["phpCAS"]."/CAS.php");
 
         $session_id = preg_replace('/[^a-zA-Z0-9\-]/','',$ticket2logout);
 

--- a/CASAuth.php
+++ b/CASAuth.php
@@ -1,12 +1,12 @@
 <?php
 /*
- * CASification script for MediaWiki 1.16 with phpCAS 1.2.1
+ * CASification script for MediaWiki 1.27 with phpCAS 1.3.3
  *
- * Requires phpCAS: http://www.ja-sig.org/wiki/display/CASC/phpCAS
+ * Requires phpCAS: https://wiki.jasig.org/display/CASC/phpCAS
  * Install by adding this line to LocalSetting.php:
  *  require_once("$IP/extensions/CASAuth/CASAuth.php");
  *
- * *** Please keep all configuration in the CASAuth.conf file ***
+ * *** Please keep all configuration in the CASAuthSettings.php file ***
  *
  * Revision History
  *   Original Revision: Ioannis Yessios
@@ -17,18 +17,21 @@
  *                      chris [dot] n [at] free [dot] fr
  *   Which was based on the original script using CAS Utils by Victor Chen
  *                      Yvchen [at] sfu [dot] ca
- *   Cleaned up and bugfixed: Stefan Sundin recover89 [at] gmail [dot] com
+ *   Cleaned up and bugfixed: Stefan Sundin
+ *                      recover89 [at] gmail [dot] com
  *   User filtering code, seperation of config and code cleanup: Aaron Russo
  *                      arusso [at] berkeley [dot] edu
  *   Email lookup hook added: Amir Tahvildaran
  *                      amirdt22 [at] gmail [dot] com
+ *   MW 1.27 compatibility: Jeffrey Gill
+ *                      jeffrey [dot] p [dot] gill [at] gmail [dot] com
  */
 
 $wgExtensionCredits["other"][] = array(
         "name"        => "CASAuth",
         "version"     => "2.0.3-ucb",
-        "author"      => "Ioannis Yessios, Hauke Pribnow, Aaron Russo",
-        "url"         => "https://github.com/arusso23/CASAuth",
+        "author"      => "Ioannis Yessios, Hauke Pribnow, Aaron Russo, Jeffrey Gill",
+        "url"         => "https://github.com/CWRUChielLab/CASAuth",
         "description" => "Overrides MediaWiki's Authentication and implements Central Authentication Service (CAS) Authentication.  Original url: http://www.mediawiki.org/wiki/Extension:CASAuthentication"
 );
 

--- a/CASAuth.php
+++ b/CASAuth.php
@@ -186,7 +186,6 @@ function casLogout() {
         // Get returnto value
         $returnto = $wgRequest->getVal("returnto");
         if ($returnto) {
-                $lg = Language::factory($wgLanguageCode);
                 $target = Title::newFromText($returnto);
                 if ($target && $target->getPrefixedDBkey() != SpecialPage::getTitleFor("Userlogout")->getPrefixedDBkey()) {
                         $redirecturl = $target->getFullUrl();

--- a/CASAuth.php
+++ b/CASAuth.php
@@ -62,7 +62,7 @@ require_once(__DIR__ . "/CASAuthSettings.php");
 
 // Setup hooks
 global $wgHooks;
-$wgHooks["UserLoadFromSession"][] = "casLogin";
+$wgHooks["UserLoadAfterLoadFromSession"][] = "casLogin";
 $wgHooks["UserLogoutComplete"][] = "casLogout";
 $wgHooks["GetPreferences"][] = "casPrefs";
 
@@ -86,7 +86,7 @@ function casLogoutCheck() {
 }
 
 // Login
-function casLogin($user, &$result) {
+function casLogin($user) {
         global $CASAuth;
         global $casIsSetUp;
         global $IP, $wgRequest, $wgOut;

--- a/CASAuth.php
+++ b/CASAuth.php
@@ -275,6 +275,9 @@ function casSetup() {
         global $CASAuth;
         global $casIsSetUp;
 
+        // Make the session persistent so that phpCAS doesn't change the session id
+        wfSetupSession();
+
         require_once($CASAuth["phpCAS"]."/CAS.php");
         phpCAS::client($CASAuth["Version"], $CASAuth["Server"], $CASAuth["Port"], $CASAuth["Url"], false);
         phpCAS::setSingleSignoutCallback('casSingleSignOut');

--- a/CASAuth.php
+++ b/CASAuth.php
@@ -161,11 +161,6 @@ function casLogin($user) {
                           }
                         }
                 }
-                else if ($_REQUEST["title"] == SpecialPage::getTitleFor("Userlogout")->getPrefixedDBkey())
-                  {
-                    // Logout
-                    casLogout();
-                  }
         }
 
         // Back to MediaWiki home after login
@@ -176,12 +171,9 @@ function casLogin($user) {
 function casLogout() {
         global $CASAuth;
         global $casIsSetUp;
-        global $wgUser, $wgRequest;
+        global $wgRequest;
 
         require_once($CASAuth["phpCAS"]."/CAS.php");
-
-        // Logout from MediaWiki
-        $wgUser->logout();
 
         // Get returnto value
         $returnto = $wgRequest->getVal("returnto");

--- a/CASAuth.php
+++ b/CASAuth.php
@@ -89,7 +89,7 @@ function casLogoutCheck() {
 function casLogin($user, &$result) {
         global $CASAuth;
         global $casIsSetUp;
-        global $IP, $wgLanguageCode, $wgRequest, $wgOut;
+        global $IP, $wgRequest, $wgOut;
 
         if (isset($_REQUEST["title"])) {
 
@@ -176,7 +176,7 @@ function casLogin($user, &$result) {
 function casLogout() {
         global $CASAuth;
         global $casIsSetUp;
-        global $wgUser, $wgRequest, $wgLanguageCode;
+        global $wgUser, $wgRequest;
 
         require_once($CASAuth["phpCAS"]."/CAS.php");
 

--- a/CASAuth.php
+++ b/CASAuth.php
@@ -43,7 +43,7 @@ $CASAuth = array(
         "LogoutServers"  => false,
         "Port"           => 443,
         "Url"            => "/cas/",
-        "Version"        => "2.0.3-ucb",
+        "Version"        => "2.0",
         "CreateAccounts" => false,     
         "PwdSecret"      => "Secret",
 

--- a/CASAuthSettings.php.template
+++ b/CASAuthSettings.php.template
@@ -95,6 +95,14 @@ function casNameLookup($username) {
   return $username;
 }
 
+# If you dont like the uid that CAS returns (ie. it returns a number) you can
+# modify the routine below to return a customized real name instead.
+#
+# Default: Returns the username, untouched
+function casRealNameLookup($username) {
+  return $username;
+}
+
 # If your users aren't all on the same email domain you can
 # modify the routine below to return their email address
 #

--- a/CASAuthSettings.php.template
+++ b/CASAuthSettings.php.template
@@ -95,14 +95,6 @@ function casNameLookup($username) {
   return $username;
 }
 
-# If you dont like the uid that CAS returns (ie. it returns a number) you can
-# modify the routine below to return a customized real name instead.
-#
-# Default: Returns the username, untouched
-function casRealNameLookup($username) {
-  return $username;
-}
-
 # If your users aren't all on the same email domain you can
 # modify the routine below to return their email address
 #
@@ -112,3 +104,44 @@ function casEmailLookup($username) {
   return $username."@".$CASAuth["EmailDomain"];
 }
 
+# If you dont like the uid that CAS returns (ie. it returns a number) you can
+# modify the routine below to return a customized real name instead.
+#
+# Default: Returns the username, untouched
+function casRealNameLookup($username) {
+  return $username;
+}
+
+/*
+# If you would like to use ldap to retrieve real names, you can use these
+# functions instead. Remember to fill in appropriate parameters for ldap.
+function casRealNameLookup($username) {
+  return @casRealNameLookupFromLDAP($username);
+}
+
+function casRealNameLookupFromLDAP($username) {
+  try {
+    # login to the LDAP server
+    $ldap = ldap_connect("host");
+    $bind = ldap_bind($ldap, "bind_rdn", "bind_password");
+
+    # look up the user's name by user id
+    $result = ldap_search($ldap, "base_dn", "(uid=$username)");
+    $info = ldap_get_entries($ldap, $result);
+
+    $first_name = $info[0]["givenname"][0];
+    $last_name  = $info[0]["sn"][0];
+
+    # log out of the server
+    ldap_unbind($ldap);
+
+    $realname = $first_name . " " . $last_name;
+  } catch (Exception $e) {}
+
+  if ($realname == " " || $realname == "" || $realname == NULL) {
+    $realname = $username;
+  }
+
+  return $realname;
+}
+*/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 CASAuth(entication) Extension for Mediawiki
 ===========================================
 
-A CAS Authentication extension for Mediawiki. Tested with versions with
-1.19, although it should work for at least versions 1.16+, if not earlier.
+A CAS Authentication extension for Mediawiki 1.27, 1.23 (and possibly
+earlier).
 
 Introduction
 ------------
@@ -14,12 +14,10 @@ installation.  This particular code is derived from work found
 This code is customized towards usage for private wikis, with the ability to
 restrict access to the wiki to specific usernames.
 
-This extension is currently written for, and tested against Mediawiki 1.19. 
-However, if you find it works well against a different version of Mediawiki,
-please feel free to let me know and I will keep track of it in this README.
-
-The extension will follow whatever version of Mediawiki is found in the
-[EPEL](http://fedoraproject.org/wiki/EPEL EPEL) repository.
+This extension is currently written for and tested against Mediawiki 1.27 and
+1.23 with phpCAS 1.3.3. However, if you find it works well against a different
+version of Mediawiki and/or phpCAS, please feel free to let me know and I will
+keep track of it in this README.
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -34,11 +34,10 @@ Assume $WIKI is the directory for your wiki.
 3.  Download the [phpCAS](https://wiki.jasig.org/display/CASC/phpCAS) extension
     and extract it to the folder $WIKI/extensions/CASAuth/CAS/
 
-4.  Add the following lines to your LocalSettings.php
+4.  Add the following line to your LocalSettings.php
 
     ```php
     require_once( "$IP/extensions/CASAuth/CASAuth.php" );
-    casSetup();
     ```
 
 5.  In the $WIKI/extensions/CASAuth/ directory, copy the


### PR DESCRIPTION
This PR proposes a new CA Certificate setting that is implemented in the casSetup function.

It also adds a check in casLogin() to see whether a user is already authenticated through another web application before forcing the authentication. This ensures that the phpCAS:getUser() method is able to get the username in the event the user is already authenticated through another session, and prevents the user from needing to log out of their institution's applications before logging into the MediaWiki.